### PR TITLE
fixed typo in defaults.yaml

### DIFF
--- a/elasticsearch/defaults.yaml
+++ b/elasticsearch/defaults.yaml
@@ -16,7 +16,7 @@ Debian:
       path: /etc/default/elasticsearch
     main: {}
     logging: {}
-RedHat: {}
+RedHat:
   repo: {}
   pkgs:
     - elasticsearch


### PR DESCRIPTION
Removed the extraneous {} in the RedHat block.
