### PR TITLE
Fix doubled backslash in ES config

### DIFF
--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -47,7 +47,7 @@ elasticsearch_defaults_file:
     - group: {{ f.group|default('root') }}
     - template: jinja
     - context:
-      datamap: {{ datamap }}
+      datamap: {{ datamap|json }}
     - watch_in:
       - service: elasticsearch
 {% endif %}
@@ -64,7 +64,7 @@ elasticsearch_config_main:
     - group: {{ f.group|default('root') }}
     - template: jinja
     - context:
-      datamap: {{ datamap }}
+      datamap: {{ datamap|json }}
     - watch_in:
       - service: elasticsearch
 {% endif %}
@@ -81,7 +81,7 @@ elasticsearch_config_logging:
     - group: {{ f.group|default('root') }}
     - template: jinja
     - context:
-      datamap: {{ datamap }}
+      datamap: {{ datamap|json }}
     - watch_in:
       - service: elasticsearch
 {% endif %}


### PR DESCRIPTION
Had this problem when trying to use a regex for [http.cors.allow-origin](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html). It would turn something like `/https?:\/\/localhost(:[0-9]+)?/` into `/https?:\\/\\/localhost(:[0-9]+)?/` in the config (not the doubled backslashes), so it was impossible to do this.

This is a hacky way to fix this problem, but the only one I know of right now. See this issue for discussion: https://github.com/saltstack/salt/issues/6435